### PR TITLE
docs: add Neo4j clean-architecture migration playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Deployment](#deployment)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
+- [Architecture Notes](#architecture-notes)
 - [Contributing](#contributing)
 - [Credits](#credits)
 - [License](#license)
@@ -129,6 +130,12 @@ Full deployment guide is in [LIARA_DEPLOYMENT_GUIDE.md](LIARA_DEPLOYMENT_GUIDE.m
    ```
 - **Network Issues**: Custom DNS handler is provided for Iranian networks.
 - **SignalR Issues**: Blazor Server is configured for optimal connections.
+
+---
+
+## Architecture Notes
+
+- Neo4j migration framework and AI prompt template: [docs/neo4j-clean-architecture-migration-playbook.md](docs/neo4j-clean-architecture-migration-playbook.md).
 
 ---
 

--- a/docs/neo4j-clean-architecture-migration-playbook.md
+++ b/docs/neo4j-clean-architecture-migration-playbook.md
@@ -1,10 +1,350 @@
-# Neo4j Migration Playbook (Clean Architecture + Microkernel Plugins)
+# Neo4j Backend Migration Blueprint
 
-This document captures a structured analytical framework for migrating a backend system to **Neo4j** while adhering to **Clean Architecture** and **Modular Plugin (Microkernel)** principles.
+This blueprint defines a **strict Clean Architecture + Microkernel/Plugin** backend migration strategy to Neo4j while preserving the existing frontend and API contract.
 
-## I. Optimized Prompt for Codex/GPT Models
+> Recommended concrete stack for this repository context: **ASP.NET Core (.NET 9) + Neo4j.Driver**.
 
-Use this prompt template to produce architecture-first outputs with strict boundaries and minimal hallucination.
+---
+
+## 1) Target Architecture (Clean + Plugin)
+
+### 1.1 Layering Rules (Non-Negotiable)
+
+- **Domain (Entities + Value Objects + Domain Interfaces)** has zero dependency on framework, HTTP, database, or logging packages.
+- **Application (Use Cases)** depends only on Domain abstractions.
+- **Adapters (HTTP, Persistence, Messaging)** implement Application/Domain ports.
+- **Infrastructure (Neo4j driver, hosting, plugin loader)** is outermost and depends inward.
+- Dependency direction always points inward.
+
+### 1.2 Microkernel Rules
+
+- Kernel owns process startup, config, observability, DI root, HTTP host, event bus, and plugin lifecycle.
+- Each feature is an isolated plugin package with:
+  - its own domain/application/adapter folders,
+  - a plugin manifest,
+  - explicit route registration.
+- Plugins communicate through kernel abstractions (`IEventBus`, contracts), not by direct references.
+
+---
+
+## 2) Deliverable A — File Structure
+
+```text
+/src
+  /Kernel
+    /Abstractions
+      IPlugin.cs
+      IPluginContext.cs
+      IEventBus.cs
+      IUnitOfWork.cs
+      INeo4jSessionFactory.cs
+    /Bootstrap
+      ServiceCollectionExtensions.cs
+      PluginLoader.cs
+      Neo4jRegistration.cs
+    /Hosting
+      KernelHost.cs
+      RouteRegistry.cs
+
+  /Plugins
+    /UserModule
+      /Domain
+        User.cs
+        IUserRepository.cs
+      /Application
+        CreateUserUseCase.cs
+        GetUserByIdUseCase.cs
+      /Adapters
+        /Neo4j
+          Neo4jUserRepository.cs
+          UserCypher.cs
+        /Http
+          UserEndpoints.cs
+          UserDtos.cs
+      UserPlugin.cs
+      user-module.plugin.json
+
+/tests
+  /Kernel.Tests
+    PluginLoaderTests.cs
+  /UserModule.Tests
+    CreateUserUseCaseTests.cs
+```
+
+---
+
+## 3) Deliverable B — Core Interface Definitions (C#)
+
+### 3.1 Plugin contract
+
+```csharp
+namespace Kernel.Abstractions;
+
+public interface IPlugin
+{
+    string Name { get; }
+    Task InitializeAsync(IPluginContext context, CancellationToken ct);
+    Task StartAsync(CancellationToken ct);
+    Task StopAsync(CancellationToken ct);
+    void MapEndpoints(IEndpointRouteBuilder app);
+}
+```
+
+### 3.2 Plugin context + shared kernel services
+
+```csharp
+namespace Kernel.Abstractions;
+
+public interface IPluginContext
+{
+    IServiceProvider Services { get; }
+    IConfiguration Configuration { get; }
+    ILoggerFactory LoggerFactory { get; }
+    IEventBus EventBus { get; }
+    INeo4jSessionFactory Neo4j { get; }
+}
+
+public interface IEventBus
+{
+    Task PublishAsync<TEvent>(TEvent evt, CancellationToken ct);
+    IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler);
+}
+
+public interface INeo4jSessionFactory
+{
+    IAsyncSession OpenReadSession();
+    IAsyncSession OpenWriteSession();
+}
+```
+
+### 3.3 Plugin manifest model
+
+```csharp
+public sealed class PluginManifest
+{
+    public required string Name { get; init; }
+    public required string AssemblyPath { get; init; }
+    public required string EntryType { get; init; } // fully qualified type implementing IPlugin
+    public bool Enabled { get; init; } = true;
+}
+```
+
+---
+
+## 4) Deliverable C — Neo4j Repository Pattern (Adapter isolation)
+
+### 4.1 Domain entity + repository port
+
+```csharp
+namespace Plugins.UserModule.Domain;
+
+public sealed class User
+{
+    public Guid Id { get; }
+    public string Mobile { get; }
+    public string DisplayName { get; }
+
+    public User(Guid id, string mobile, string displayName)
+    {
+        Id = id;
+        Mobile = mobile;
+        DisplayName = displayName;
+    }
+}
+
+public interface IUserRepository
+{
+    Task<User?> GetByIdAsync(Guid id, CancellationToken ct);
+    Task CreateAsync(User user, CancellationToken ct);
+}
+```
+
+### 4.2 Use case stays database-agnostic
+
+```csharp
+namespace Plugins.UserModule.Application;
+
+public sealed class CreateUserUseCase
+{
+    private readonly IUserRepository _repo;
+
+    public CreateUserUseCase(IUserRepository repo) => _repo = repo;
+
+    public async Task ExecuteAsync(Guid id, string mobile, string displayName, CancellationToken ct)
+    {
+        var user = new User(id, mobile, displayName);
+        await _repo.CreateAsync(user, ct);
+    }
+}
+```
+
+### 4.3 Neo4j adapter implementation
+
+```csharp
+namespace Plugins.UserModule.Adapters.Neo4j;
+
+public sealed class Neo4jUserRepository : IUserRepository
+{
+    private readonly INeo4jSessionFactory _sessions;
+
+    public Neo4jUserRepository(INeo4jSessionFactory sessions) => _sessions = sessions;
+
+    public async Task<User?> GetByIdAsync(Guid id, CancellationToken ct)
+    {
+        const string cypher = """
+            MATCH (u:User {id: $id})
+            RETURN u.id AS id, u.mobile AS mobile, u.displayName AS displayName
+            LIMIT 1
+            """;
+
+        await using var session = _sessions.OpenReadSession();
+        var cursor = await session.RunAsync(cypher, new { id = id.ToString() });
+        var record = await cursor.SingleOrDefaultAsync();
+        if (record is null) return null;
+
+        return new User(
+            Guid.Parse(record["id"].As<string>()),
+            record["mobile"].As<string>(),
+            record["displayName"].As<string>()
+        );
+    }
+
+    public async Task CreateAsync(User user, CancellationToken ct)
+    {
+        const string cypher = """
+            CREATE (u:User {id: $id, mobile: $mobile, displayName: $displayName})
+            """;
+
+        await using var session = _sessions.OpenWriteSession();
+        await session.RunAsync(cypher, new
+        {
+            id = user.Id.ToString(),
+            mobile = user.Mobile,
+            displayName = user.DisplayName
+        });
+    }
+}
+```
+
+### 4.4 Relationship-first graph modeling example
+
+```cypher
+// user purchases product with transaction metadata
+MATCH (u:User {id:$userId}), (p:Product {id:$productId})
+MERGE (u)-[r:PURCHASED]->(p)
+SET r.lastPurchasedAt = datetime(),
+    r.count = coalesce(r.count, 0) + 1,
+    r.totalAmount = coalesce(r.totalAmount, 0) + $amount;
+```
+
+---
+
+## 5) Deliverable D — Runtime DI + Dynamic Plugin Loading
+
+### 5.1 Kernel startup sequence
+
+1. Build root `ServiceCollection`.
+2. Register singleton `IDriver` and `INeo4jSessionFactory`.
+3. Read plugin manifests from `/plugins/**.plugin.json`.
+4. For each enabled plugin:
+   - Load assembly (`AssemblyLoadContext`),
+   - instantiate `EntryType` implementing `IPlugin`,
+   - call `InitializeAsync(context)`.
+5. After all initialized, call `StartAsync`.
+6. Map endpoints from each plugin on the shared ASP.NET pipeline.
+
+### 5.2 DI registration (kernel)
+
+```csharp
+public static class Neo4jRegistration
+{
+    public static IServiceCollection AddNeo4j(this IServiceCollection services, IConfiguration cfg)
+    {
+        services.AddSingleton<IDriver>(_ => GraphDatabase.Driver(
+            cfg["Neo4j:Uri"],
+            AuthTokens.Basic(cfg["Neo4j:User"], cfg["Neo4j:Password"])
+        ));
+
+        services.AddSingleton<INeo4jSessionFactory, Neo4jSessionFactory>();
+        return services;
+    }
+}
+```
+
+### 5.3 Plugin entry implementation
+
+```csharp
+public sealed class UserPlugin : IPlugin
+{
+    public string Name => "UserModule";
+
+    public Task InitializeAsync(IPluginContext context, CancellationToken ct)
+    {
+        var services = context.Services.GetRequiredService<IServiceCollection>();
+        services.AddScoped<IUserRepository, Neo4jUserRepository>();
+        services.AddScoped<CreateUserUseCase>();
+        services.AddScoped<GetUserByIdUseCase>();
+        return Task.CompletedTask;
+    }
+
+    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public void MapEndpoints(IEndpointRouteBuilder app)
+        => UserEndpoints.Map(app);
+}
+```
+
+> Implementation note: in production, prefer a dedicated plugin service registration abstraction over exposing raw `IServiceCollection` through context.
+
+---
+
+## 6) Migration Strategy (Execution Plan)
+
+### Phase 1 — Kernel + Contract Hardening
+- Freeze plugin contracts and publish versioned package (e.g., `Kernel.Abstractions v1`).
+- Add contract tests ensuring plugin lifecycle and endpoint mapping invariants.
+- Add observability baseline: request IDs, query timings, plugin health endpoints.
+
+### Phase 2 — Graph Modeling and Query Contracts
+- Define canonical graph aggregates (`User`, `Order`, `Product`, `InventoryItem`, etc.).
+- Encode relationship semantics and cardinality rules.
+- Add constraints/indexes early:
+
+```cypher
+CREATE CONSTRAINT user_id_unique IF NOT EXISTS
+FOR (u:User) REQUIRE u.id IS UNIQUE;
+
+CREATE INDEX product_sku_idx IF NOT EXISTS
+FOR (p:Product) ON (p.sku);
+```
+
+### Phase 3 — Vertical Slice Pilot (UserModule)
+- Port one bounded context end-to-end.
+- Keep endpoint path, HTTP verb, request/response DTO shape identical.
+- Run backward-compatibility contract tests against old/new backends.
+
+### Phase 4 — Strangler Rollout
+- Route migrated modules to new kernel.
+- Keep non-migrated modules on legacy backend.
+- Optionally enable dual writes/CDC for short sync windows.
+
+### Phase 5 — Decommission
+- Freeze writes on legacy.
+- Execute final delta sync.
+- Switch 100% traffic and archive legacy data.
+
+---
+
+## 7) API Compatibility Guardrails
+
+- Preserve URL paths, status codes, validation messages, and paging formats.
+- Add API snapshot tests for JSON payload parity.
+- Use consumer-driven contract tests where frontend expects strict shapes.
+
+---
+
+## 8) Optimized Prompt (for Codex/GPT)
 
 ```text
 Act as a Senior Software Architect specializing in Graph Databases and Modular Systems.
@@ -12,110 +352,25 @@ Act as a Senior Software Architect specializing in Graph Databases and Modular S
 Objective: Design a backend migration strategy to Neo4j with a strictly enforcing "Clean Architecture" and a "Microkernel/Plugin" pattern.
 
 Context:
-- Current Backend: [Insert Language/Framework, e.g., Node.js Express / Python FastAPI / Java Spring]
-- Target Database: Neo4j (using Cypher query language)
-- Frontend: Existing UI must remain untouched. The API contract (REST/GraphQL) must remain identical.
+- Current Backend: ASP.NET Core (.NET 9 Web API)
+- Target Database: Neo4j (Cypher)
+- Frontend: Existing UI must remain untouched. REST API contract must remain identical.
 
 Architectural Constraints:
-1. Clean Architecture: Strict separation of concerns. Outer layers (Frameworks, DB) depend on inner layers (Use Cases, Entities).
-2. Pluggable Modularity: The core system (Kernel) handles infrastructure and orchestration. Every business feature (e.g., Auth, Inventory, User Management) must be a standalone plugin that implements a strict Interface.
-3. Graph Modeling: Do not simply translate SQL tables to Nodes. Utilize graph relationships (e.g., (:User)-[:PURCHASED]->(:Product)).
+1) Enforce Clean Architecture dependency direction inward only.
+2) Implement Microkernel where each business domain is a standalone plugin implementing a strict IPlugin interface.
+3) Model graph by relationships-first semantics, not SQL table mirroring.
+4) Keep Domain and Use Cases database-agnostic.
 
 Deliverables:
-1. File Structure: A tree view showing the separation between the Core Kernel and a sample Plugin.
-2. Core Interface Definitions: Abstract interfaces (in [Language]) that plugins must implement to hook into the Core.
-3. Neo4j Repository Pattern: Code showing how the "Interface Adapter" layer interacts with the Neo4j driver, ensuring the Domain layer remains agnostic of the database.
-4. Dependency Injection: Explain how plugins are loaded dynamically at runtime.
+1) File tree (Kernel + one UserModule plugin).
+2) C# interfaces for IPlugin, IPluginContext, IEventBus, IUserRepository.
+3) Repository adapter example with Neo4j.Driver and Cypher, isolated from Domain.
+4) Runtime plugin loading + DI flow using manifests and assembly loading.
+5) HTTP endpoint example preserving an existing API contract.
 
-Generate the architectural blueprint and code skeletons for the Core Kernel and one example Plugin (e.g., UserModule).
+Output style:
+- Provide compilable C# skeletons.
+- Mark boundaries explicitly (Domain/Application/Adapters/Infrastructure).
+- Include migration phases and risk controls.
 ```
-
----
-
-## II. Strategic Migration Plan
-
-### Phase 1: Architectural Foundation (Microkernel)
-1. **Define plugin contracts**
-   - Lifecycle methods (`initialize`, `start`, `stop`)
-   - Route registration API
-2. **Implement core kernel**
-   - Configuration loading
-   - Neo4j driver initialization (singleton connection pool)
-   - Dynamic plugin discovery/loading
-   - Global logging/error handling
-3. **Establish event bus**
-   - Internal Pub/Sub for plugin communication
-   - Avoid direct plugin-to-plugin dependencies
-
-### Phase 2: Graph Data Modeling (Schema Redesign)
-1. **Entity analysis**: identify graph nodes and relationship types.
-2. **Relationship reification**: convert foreign keys/join tables into meaningful relationships with properties.
-3. **Access-pattern optimization**: optimize model for top read/write traversal paths.
-
-### Phase 3: Vertical Slice Pilot
-1. **Create one pilot plugin** using domain/use-case/adapter layering.
-2. **Preserve API contract** so the frontend remains unchanged.
-3. **Build ETL path** (legacy export -> Neo4j import via `LOAD CSV` or tooling).
-
-### Phase 4: Parallel Rollout (Strangler Fig)
-1. **Proxy-based traffic routing** between migrated and legacy modules.
-2. **Dual writes / CDC** for synchronization during transition (optional but recommended).
-
----
-
-## III. Milestones
-
-### Milestone 1: Kernel & Infrastructure Alpha
-- Monorepo structure for Core + Plugins
-- Neo4j provisioned (Docker/AuraDB)
-- DI container in core kernel
-- Plugin interface contract implemented
-- Unit tests proving dynamic loading of a mock plugin
-
-### Milestone 2: Graph Model & Pilot Module
-- Finalized graph schema diagram
-- First production-capable plugin (e.g., user auth)
-- Cypher repositories hidden behind domain interfaces
-- Pilot ETL script (v1)
-- Validation: frontend workflow unchanged
-
-### Milestone 3: Core Domain Migration
-- Migration of high-value business modules
-- Complex traversal features (recommendations/impact analysis)
-- Cypher profiling and index tuning
-
-### Milestone 4: Legacy Decommissioning
-- Full bulk import complete
-- 100% routing cutover
-- Legacy database shutdown + archival
-
----
-
-## IV. Clean + Pluggable Pattern Example
-
-### Suggested Structure
-
-```text
-/src
-  /core             <-- Microkernel
-    /infra          <-- Neo4j driver setup
-    /interfaces     <-- Plugin contracts
-    /loader         <-- Dynamic plugin loader
-  /plugins
-    /user-module    <-- Self-contained plugin
-      /domain       <-- Entities (User)
-      /usecases     <-- CreateUser, FindUser
-      /adapters
-        /http       <-- Controllers (frontend-compatible API)
-        /neo4j      <-- Cypher queries
-      index.ts      <-- Entry point implementing plugin contract
-```
-
-### Dependency Injection Flow
-1. Core starts and connects to Neo4j.
-2. Core scans the plugin directory.
-3. Core injects shared infra (Neo4j/session/logger/config) into each plugin.
-4. Plugin binds infra to adapter implementations (e.g., repositories).
-5. Plugin registers endpoints with the core HTTP host.
-
-This keeps the core feature-agnostic while preserving independent plugin ownership.

--- a/docs/neo4j-clean-architecture-migration-playbook.md
+++ b/docs/neo4j-clean-architecture-migration-playbook.md
@@ -1,0 +1,121 @@
+# Neo4j Migration Playbook (Clean Architecture + Microkernel Plugins)
+
+This document captures a structured analytical framework for migrating a backend system to **Neo4j** while adhering to **Clean Architecture** and **Modular Plugin (Microkernel)** principles.
+
+## I. Optimized Prompt for Codex/GPT Models
+
+Use this prompt template to produce architecture-first outputs with strict boundaries and minimal hallucination.
+
+```text
+Act as a Senior Software Architect specializing in Graph Databases and Modular Systems.
+
+Objective: Design a backend migration strategy to Neo4j with a strictly enforcing "Clean Architecture" and a "Microkernel/Plugin" pattern.
+
+Context:
+- Current Backend: [Insert Language/Framework, e.g., Node.js Express / Python FastAPI / Java Spring]
+- Target Database: Neo4j (using Cypher query language)
+- Frontend: Existing UI must remain untouched. The API contract (REST/GraphQL) must remain identical.
+
+Architectural Constraints:
+1. Clean Architecture: Strict separation of concerns. Outer layers (Frameworks, DB) depend on inner layers (Use Cases, Entities).
+2. Pluggable Modularity: The core system (Kernel) handles infrastructure and orchestration. Every business feature (e.g., Auth, Inventory, User Management) must be a standalone plugin that implements a strict Interface.
+3. Graph Modeling: Do not simply translate SQL tables to Nodes. Utilize graph relationships (e.g., (:User)-[:PURCHASED]->(:Product)).
+
+Deliverables:
+1. File Structure: A tree view showing the separation between the Core Kernel and a sample Plugin.
+2. Core Interface Definitions: Abstract interfaces (in [Language]) that plugins must implement to hook into the Core.
+3. Neo4j Repository Pattern: Code showing how the "Interface Adapter" layer interacts with the Neo4j driver, ensuring the Domain layer remains agnostic of the database.
+4. Dependency Injection: Explain how plugins are loaded dynamically at runtime.
+
+Generate the architectural blueprint and code skeletons for the Core Kernel and one example Plugin (e.g., UserModule).
+```
+
+---
+
+## II. Strategic Migration Plan
+
+### Phase 1: Architectural Foundation (Microkernel)
+1. **Define plugin contracts**
+   - Lifecycle methods (`initialize`, `start`, `stop`)
+   - Route registration API
+2. **Implement core kernel**
+   - Configuration loading
+   - Neo4j driver initialization (singleton connection pool)
+   - Dynamic plugin discovery/loading
+   - Global logging/error handling
+3. **Establish event bus**
+   - Internal Pub/Sub for plugin communication
+   - Avoid direct plugin-to-plugin dependencies
+
+### Phase 2: Graph Data Modeling (Schema Redesign)
+1. **Entity analysis**: identify graph nodes and relationship types.
+2. **Relationship reification**: convert foreign keys/join tables into meaningful relationships with properties.
+3. **Access-pattern optimization**: optimize model for top read/write traversal paths.
+
+### Phase 3: Vertical Slice Pilot
+1. **Create one pilot plugin** using domain/use-case/adapter layering.
+2. **Preserve API contract** so the frontend remains unchanged.
+3. **Build ETL path** (legacy export -> Neo4j import via `LOAD CSV` or tooling).
+
+### Phase 4: Parallel Rollout (Strangler Fig)
+1. **Proxy-based traffic routing** between migrated and legacy modules.
+2. **Dual writes / CDC** for synchronization during transition (optional but recommended).
+
+---
+
+## III. Milestones
+
+### Milestone 1: Kernel & Infrastructure Alpha
+- Monorepo structure for Core + Plugins
+- Neo4j provisioned (Docker/AuraDB)
+- DI container in core kernel
+- Plugin interface contract implemented
+- Unit tests proving dynamic loading of a mock plugin
+
+### Milestone 2: Graph Model & Pilot Module
+- Finalized graph schema diagram
+- First production-capable plugin (e.g., user auth)
+- Cypher repositories hidden behind domain interfaces
+- Pilot ETL script (v1)
+- Validation: frontend workflow unchanged
+
+### Milestone 3: Core Domain Migration
+- Migration of high-value business modules
+- Complex traversal features (recommendations/impact analysis)
+- Cypher profiling and index tuning
+
+### Milestone 4: Legacy Decommissioning
+- Full bulk import complete
+- 100% routing cutover
+- Legacy database shutdown + archival
+
+---
+
+## IV. Clean + Pluggable Pattern Example
+
+### Suggested Structure
+
+```text
+/src
+  /core             <-- Microkernel
+    /infra          <-- Neo4j driver setup
+    /interfaces     <-- Plugin contracts
+    /loader         <-- Dynamic plugin loader
+  /plugins
+    /user-module    <-- Self-contained plugin
+      /domain       <-- Entities (User)
+      /usecases     <-- CreateUser, FindUser
+      /adapters
+        /http       <-- Controllers (frontend-compatible API)
+        /neo4j      <-- Cypher queries
+      index.ts      <-- Entry point implementing plugin contract
+```
+
+### Dependency Injection Flow
+1. Core starts and connects to Neo4j.
+2. Core scans the plugin directory.
+3. Core injects shared infra (Neo4j/session/logger/config) into each plugin.
+4. Plugin binds infra to adapter implementations (e.g., repositories).
+5. Plugin registers endpoints with the core HTTP host.
+
+This keeps the core feature-agnostic while preserving independent plugin ownership.


### PR DESCRIPTION
### Motivation
- Provide a concise, actionable migration playbook for moving backend modules to Neo4j while enforcing Clean Architecture and a pluggable (microkernel/plugin) pattern.
- Supply an optimized Codex/GPT prompt to reliably generate architecture-constrained code skeletons and reduce hallucination during automated code generation.

### Description
- Add `docs/neo4j-clean-architecture-migration-playbook.md` containing the prompt template, phased migration plan, milestones, and a sample core/plugin structure and DI flow. 
- Update `README.md` to include an `Architecture Notes` entry and link to the new playbook via `docs/neo4j-clean-architecture-migration-playbook.md`.
- The playbook covers plugin contracts (`initialize`, `start`, `stop`), Neo4j driver initialization, dynamic plugin discovery/loading, ETL guidance, and a suggested repository/adapter layout.

### Testing
- Ran `git diff --check` to validate repository formatting and diffs which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948d0e96d4832bafc81018eb49ae0b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README.md with new Architecture Notes section linked in the Table of Contents
  * Added comprehensive migration playbook documentation detailing architectural patterns, implementation guidance, data modeling approaches, migration phases, and code structure examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->